### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scipy==1.9.2
 timm==0.6.11
 tokenizers==0.13.1
 tqdm==4.64.1
-transformers==4.23.1
+transformers==4.46.3
 yacs
 einops
 termcolor


### PR DESCRIPTION
Modification of the version of transformers as current version (4.23.1) doesn't have AutoImageProcessor attribute