### PR TITLE
Fix duplicate and deprecated BertModel import in _utils.py

### DIFF
--- a/lib/_utils.py
+++ b/lib/_utils.py
@@ -3,7 +3,7 @@ import sys
 import torch
 from torch import nn
 from torch.nn import functional as F
-from bert.modeling_bert import BertModel
+from transformers import BertModel
 
 
 def load_weights(model, load_path):


### PR DESCRIPTION
Removes the deprecated and unused BertModel import from bert.modeling_bert in lib/_utils.py.